### PR TITLE
added raw value getters 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,13 @@ bitflags = "1.2"
 embedded-hal = "=1.0.0"
 log = "0.4"
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-linux-embedded-hal = "0.4.0"
-anyhow = "1.0.80"
+
+# no_std!
+#linux-embedded-hal = "0.4.0"
+#anyhow = "1.0.80"
+
+# no_std :)
+anyhow = { version = "1.0.80", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,21 @@ impl FieldData {
         self.humidity as f32 / 1000f32
     }
 
+    /// Temperature in degree celsius (°C)
+    pub fn temperature_celsius_raw(&self) -> i16 {
+        self.temperature
+    }
+
+    /// Pressure in hectopascal (hPA)
+    pub fn pressure_hpa_raw(&self) -> u32 {
+        self.pressure
+    }
+
+    /// Humidity in % relative humidity
+    pub fn humidity_percent_raw(&self) -> u32 {
+        self.humidity
+    }
+
     pub fn gas_resistance_ohm(&self) -> u32 {
         self.gas_resistance
     }


### PR DESCRIPTION
PR Adds raw value getters to avoid using `f32` on small microcontrollers like STM32L0 with Cortex M0 core.


I noticed you have not enables `issues`, so posting here:

`linux-embedded-hal` can't be used on Thumv6 targets, it adds a lot of stuff that uses `std` and doesn't work in `no_std` environment.

Unfortunately I have no idea how to conditionally add dependencies for Linux target.

When I figure out I'll be doing another PR.